### PR TITLE
feat(changes)!: move config to event details

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,16 +43,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "chrono-tz"
-version = "0.10.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
-dependencies = [
- "chrono",
- "phf",
-]
-
-[[package]]
 name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -103,7 +93,6 @@ version = "3.1.4"
 dependencies = [
  "anyhow",
  "chrono",
- "chrono-tz",
  "notify-debouncer-full",
  "serde",
  "serde_json",
@@ -271,24 +260,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,12 +349,6 @@ dependencies = [
  "serde",
  "serde_core",
 ]
-
-[[package]]
-name = "siphasher"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,6 @@ lto = true
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "serde"] }
-chrono-tz = "0.10"
 notify-debouncer-full = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/src/apply_details.rs
+++ b/src/apply_details.rs
@@ -39,7 +39,7 @@ fn create_event(description: &str) -> SoonToBeIcsEvent {
 fn check_alert(alert_minutes_before: Option<u16>) {
     let details = EventDetails {
         alert_minutes_before,
-        notes: None,
+        ..EventDetails::default()
     };
     let mut event = create_event("");
     apply_details(&mut event, &details);
@@ -57,8 +57,8 @@ fn alert_examples() {
 #[cfg(test)]
 fn check_description(notes: Option<&str>, event_description: &str, expected: &str) {
     let details = EventDetails {
-        alert_minutes_before: None,
         notes: notes.map(ToOwned::to_owned),
+        ..EventDetails::default()
     };
     let mut event = create_event(event_description);
     apply_details(&mut event, &details);

--- a/src/output_files.rs
+++ b/src/output_files.rs
@@ -85,12 +85,6 @@ fn one_internal(content: UserconfigFile) -> anyhow::Result<Buildresult> {
         });
     }
 
-    apply_changes(
-        &mut user_events,
-        &content.config.events,
-        content.config.removed_events,
-    );
-
     for event in &mut user_events {
         if let Some(details) = content.config.events.get(&event.name) {
             apply_details(event, details);
@@ -100,6 +94,8 @@ fn one_internal(content: UserconfigFile) -> anyhow::Result<Buildresult> {
             // skip here and wait for the user to update them in the TelegramBot
         }
     }
+
+    apply_changes(&mut user_events, content.config);
 
     user_events.sort_by_cached_key(|event| event.start_time);
     let ics_content = generate_ics(&first_name, &user_events);

--- a/src/output_files.rs
+++ b/src/output_files.rs
@@ -87,10 +87,9 @@ fn one_internal(content: UserconfigFile) -> anyhow::Result<Buildresult> {
 
     apply_changes(
         &mut user_events,
-        content.config.changes,
+        &content.config.events,
         content.config.removed_events,
-    )
-    .context("failed to apply changes")?;
+    );
 
     for event in &mut user_events {
         if let Some(details) = content.config.events.get(&event.name) {

--- a/src/userconfig.rs
+++ b/src/userconfig.rs
@@ -111,7 +111,7 @@ fn can_deserialize_userconfig_with_event_map() -> Result<(), serde_json::Error> 
 
 #[cfg(test)]
 #[track_caller]
-fn deserialize_change(json: &str, expected: &Change) {
+fn case_change(json: &str, expected: &Change) {
     let expected_date = chrono::NaiveDate::from_ymd_opt(2020, 12, 20)
         .unwrap()
         .and_hms_opt(22, 4, 0)
@@ -132,7 +132,7 @@ fn deserialize_change(json: &str, expected: &Change) {
 
 #[test]
 fn can_deserialize_minimal_change() {
-    deserialize_change(
+    case_change(
         "{}",
         &Change {
             remove: false,
@@ -146,7 +146,7 @@ fn can_deserialize_minimal_change() {
 
 #[test]
 fn can_deserialize_change_remove() {
-    deserialize_change(
+    case_change(
         r#"{"remove": true}"#,
         &Change {
             remove: true,
@@ -160,7 +160,7 @@ fn can_deserialize_change_remove() {
 
 #[test]
 fn can_deserialize_change_endtime() {
-    deserialize_change(
+    case_change(
         r#"{"endtime": "23:42:00"}"#,
         &Change {
             remove: false,

--- a/src/userconfig.rs
+++ b/src/userconfig.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
 
-use chrono::{NaiveDateTime, NaiveTime, TimeZone as _};
-use chrono_tz::Europe::Berlin;
+use chrono::{NaiveDateTime, NaiveTime};
 use serde::Deserialize;
 
 #[derive(Deserialize, Debug)]
@@ -25,11 +24,13 @@ pub enum RemovedEvents {
     Emoji,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct EventDetails {
     #[serde(default)]
     pub alert_minutes_before: Option<u16>,
+    #[serde(default)]
+    pub changes: HashMap<NaiveDateTime, Change>,
     #[serde(default)]
     pub notes: Option<String>,
 }
@@ -39,68 +40,25 @@ pub struct EventDetails {
 pub struct Userconfig {
     pub calendarfile_suffix: String,
 
-    #[serde(default)]
-    pub changes: Vec<Change>,
-
     pub events: HashMap<String, EventDetails>,
 
     #[serde(default)]
     pub removed_events: RemovedEvents,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Change {
-    pub name: String,
-
-    #[serde(deserialize_with = "deserialize_change_date")]
-    pub date: NaiveDateTime,
-
-    #[serde(default)]
-    pub add: bool,
     #[serde(default)]
     pub remove: bool,
 
-    #[serde(default, deserialize_with = "deserialize_change_time")]
-    /// Used when adapting events
+    #[serde(default)]
     pub starttime: Option<NaiveTime>,
-    #[serde(default, deserialize_with = "deserialize_change_time")]
-    /// Used for adapting and creating new events
+    #[serde(default)]
     pub endtime: Option<NaiveTime>,
 
     pub namesuffix: Option<String>,
     pub room: Option<String>,
-}
-
-fn deserialize_change_time<'de, D>(deserializer: D) -> Result<Option<NaiveTime>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let str = String::deserialize(deserializer)?;
-    let time = NaiveTime::parse_from_str(&str, "%H:%M").map_err(serde::de::Error::custom)?;
-    Ok(Some(time))
-}
-
-fn deserialize_change_date<'de, D>(deserializer: D) -> Result<NaiveDateTime, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let raw = String::deserialize(deserializer)?;
-    parse_change_date(&raw).map_err(serde::de::Error::custom)
-}
-
-fn parse_change_date(raw: &str) -> Result<NaiveDateTime, chrono::ParseError> {
-    let tless = raw.replace('T', " ");
-    let utc = NaiveDateTime::parse_from_str(&tless, "%Y-%m-%d %H:%M")?;
-    let date_time = Berlin.from_utc_datetime(&utc);
-    let naive = date_time.naive_local();
-    Ok(naive)
-}
-
-#[test]
-fn can_parse_change_date_from_utc_to_local() {
-    let actual = parse_change_date("2020-07-01T06:30").unwrap();
-    let string = actual.and_local_timezone(Berlin).unwrap().to_rfc3339();
-    assert_eq!(string, "2020-07-01T08:30:00+02:00");
 }
 
 #[test]
@@ -117,8 +75,7 @@ fn can_deserialize_chat() -> Result<(), serde_json::Error> {
 
 #[test]
 fn error_on_userconfig_without_calendarfile_suffix() {
-    let test: Result<Userconfig, serde_json::Error> =
-        serde_json::from_str(r#"{"changes": [], "events": []}"#);
+    let test: Result<Userconfig, serde_json::Error> = serde_json::from_str(r#"{"events": []}"#);
 
     let error = test.expect_err("parsing should fail");
     assert!(error.is_data());
@@ -127,10 +84,9 @@ fn error_on_userconfig_without_calendarfile_suffix() {
 #[test]
 fn can_deserialize_minimal_userconfig() -> Result<(), serde_json::Error> {
     let test: Userconfig =
-        serde_json::from_str(r#"{"calendarfileSuffix": "123qwe", "changes": [], "events": {}}"#)?;
+        serde_json::from_str(r#"{"calendarfileSuffix": "123qwe", "events": {}}"#)?;
 
     assert_eq!(test.calendarfile_suffix, "123qwe");
-    assert_eq!(test.changes.len(), 0);
     assert_eq!(test.events.len(), 0);
     assert_eq!(test.removed_events, RemovedEvents::Cancelled);
 
@@ -140,11 +96,10 @@ fn can_deserialize_minimal_userconfig() -> Result<(), serde_json::Error> {
 #[test]
 fn can_deserialize_userconfig_with_event_map() -> Result<(), serde_json::Error> {
     let test: Userconfig = serde_json::from_str(
-        r#"{"calendarfileSuffix": "123qwe", "changes": [], "events": {"BTI1-TI": {}, "BTI5-VS": {}}, "removedEvents": "removed"}"#,
+        r#"{"calendarfileSuffix": "123qwe", "events": {"BTI1-TI": {}, "BTI5-VS": {}}, "removedEvents": "removed"}"#,
     )?;
 
     assert_eq!(test.calendarfile_suffix, "123qwe");
-    assert_eq!(test.changes.len(), 0);
     assert_eq!(test.removed_events, RemovedEvents::Removed);
 
     let mut events = test.events.keys().collect::<Vec<_>>();
@@ -154,68 +109,65 @@ fn can_deserialize_userconfig_with_event_map() -> Result<(), serde_json::Error> 
     Ok(())
 }
 
-#[test]
-fn can_deserialize_minimal_change() -> Result<(), serde_json::Error> {
-    let test: Change = serde_json::from_str(r#"{"name": "Tree", "date": "2020-12-20T22:04"}"#)?;
-    assert_eq!(test.name, "Tree");
-    assert_eq!(
-        test.date,
-        chrono::NaiveDate::from_ymd_opt(2020, 12, 20)
-            .unwrap()
-            .and_hms_opt(23, 4, 0)
-            .unwrap()
-    );
-    assert!(!test.add);
-    assert!(!test.remove);
-    assert_eq!(test.starttime, None);
-    assert_eq!(test.endtime, None);
-    assert_eq!(test.namesuffix, None);
-    assert_eq!(test.room, None);
-    Ok(())
+#[cfg(test)]
+#[track_caller]
+fn deserialize_change(json: &str, expected: &Change) {
+    let expected_date = chrono::NaiveDate::from_ymd_opt(2020, 12, 20)
+        .unwrap()
+        .and_hms_opt(22, 4, 0)
+        .unwrap();
+    let config = serde_json::from_str::<Userconfig>(
+       & r#"{"calendarfileSuffix": "123qwe", "events": {"Fancy Event Name": {"changes": {"2020-12-20T22:04:00": {}}}}}"#.replace("{}", json),
+    ).expect("should be able to parse json to userconfig");
+    dbg!(&config);
+    let actual = config
+        .events
+        .get("Fancy Event Name")
+        .expect("event should exist")
+        .changes
+        .get(&expected_date)
+        .expect("date should exist");
+    assert_eq!(actual, expected);
 }
 
 #[test]
-fn can_deserialize_change_remove() -> Result<(), serde_json::Error> {
-    let test: Change =
-        serde_json::from_str(r#"{"name": "Tree", "date": "2020-12-20T22:04", "remove": true}"#)?;
-    assert_eq!(test.name, "Tree");
-    assert_eq!(
-        test.date,
-        chrono::NaiveDate::from_ymd_opt(2020, 12, 20)
-            .unwrap()
-            .and_hms_opt(23, 4, 0)
-            .unwrap()
+fn can_deserialize_minimal_change() {
+    deserialize_change(
+        "{}",
+        &Change {
+            remove: false,
+            starttime: None,
+            endtime: None,
+            namesuffix: None,
+            room: None,
+        },
     );
-    assert!(!test.add);
-    assert!(test.remove);
-    assert_eq!(test.starttime, None);
-    assert_eq!(test.endtime, None);
-    assert_eq!(test.namesuffix, None);
-    assert_eq!(test.room, None);
-    Ok(())
 }
 
 #[test]
-fn can_deserialize_change_add() -> Result<(), serde_json::Error> {
-    let test: Change = serde_json::from_str(
-        r#"{"name": "Tree", "date": "2020-12-20T22:04", "add": true, "endtime": "23:42"}"#,
-    )?;
-    assert_eq!(test.name, "Tree");
-    assert_eq!(
-        test.date,
-        chrono::NaiveDate::from_ymd_opt(2020, 12, 20)
-            .unwrap()
-            .and_hms_opt(23, 4, 0)
-            .unwrap()
+fn can_deserialize_change_remove() {
+    deserialize_change(
+        r#"{"remove": true}"#,
+        &Change {
+            remove: true,
+            starttime: None,
+            endtime: None,
+            namesuffix: None,
+            room: None,
+        },
     );
-    assert!(test.add);
-    assert!(!test.remove);
-    assert_eq!(test.starttime, None);
-    assert_eq!(
-        test.endtime,
-        Some(NaiveTime::from_hms_opt(23, 42, 0).unwrap())
+}
+
+#[test]
+fn can_deserialize_change_endtime() {
+    deserialize_change(
+        r#"{"endtime": "23:42:00"}"#,
+        &Change {
+            remove: false,
+            starttime: None,
+            endtime: Some(NaiveTime::from_hms_opt(23, 42, 0).unwrap()),
+            namesuffix: None,
+            room: None,
+        },
     );
-    assert_eq!(test.namesuffix, None);
-    assert_eq!(test.room, None);
-    Ok(())
 }


### PR DESCRIPTION
Old changes are no longer used but the new location in the config is way more fail-safe to where they should apply.